### PR TITLE
Lumberjack 8 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "rareloop/lumberjack-bedrock-installer",
     "require": {
+        "php": ">=8.1",
         "symfony/console": "^5.1",
         "symfony/process": "^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
     "name": "rareloop/lumberjack-bedrock-installer",
     "require": {
         "php": ">=8.1",
-        "symfony/console": "^5.1",
-        "symfony/process": "^5.0"
+        "symfony/console": "^6.1",
+        "symfony/process": "^6.4.14"
     },
     "autoload": {
         "psr-4": {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -335,7 +335,7 @@ class NewCommand extends Command
         file_put_contents($configPath, $appConfig);
     }
 
-    protected function runCommands(array $commands, callable $callback = null, $timeout = 3600)
+    protected function runCommands(array $commands, ?callable $callback = null, $timeout = 3600)
     {
         foreach ($commands as $command) {
             // print when in debug mode -vvv


### PR DESCRIPTION
# Lumberjack 8.0 upgrade

Maintenance upgrade requiring PHP 8.1 and above, and fixing an instance of deprecated syntax.

Also upgrades Symfony components:
* `symfony/console` - `5.1.x` → `6.1.x` (Drops PHP 7 and 8.0 support)
* `symfony/process` - `5.0.x` → `6.4.14` (Drops PHP 7 and 8.0 support - requires specific minor version due to [security vulnerabilities in prior `6.4.x` versions](https://symfony.com/blog/cve-2024-51736-command-execution-hijack-on-windows-with-process-class)